### PR TITLE
feat: align model selection with language

### DIFF
--- a/docs/acceptance-tests.md
+++ b/docs/acceptance-tests.md
@@ -31,6 +31,12 @@ These tests validate the product behavior for the offline Linux CLI.
 - Expect: model download occurs before startup completes.
 - Pass: model file exists at the default location and daemon starts.
 
+### AT-01b: Language selects model variant
+- Setup: set `language = "en"` without `model_language`.
+- Command: `sv --daemon`
+- Expect: model download uses the `.en` variant.
+- Pass: model file path resolves to `ggml-<size>.en.bin` when language is `en` and `model_language` is unset.
+
 ### AT-02: Missing model returns error
 - Setup: set `model` in config to `${XDG_DATA_HOME:-~/.local/share}/soundvibes/models/missing.bin` and set `download_model = false`.
 - Command: `sv --daemon`

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,7 +9,7 @@ use crate::error::AppError;
 
 const DEFAULT_MODEL_BASE_URL: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
 
-#[derive(Debug, Copy, Clone, ValueEnum, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModelSize {
     Auto,
@@ -40,11 +40,21 @@ impl ModelSize {
     }
 }
 
-#[derive(Debug, Copy, Clone, ValueEnum, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModelLanguage {
     Auto,
     En,
+}
+
+pub fn model_language_for_transcription(language: &str) -> ModelLanguage {
+    if language.eq_ignore_ascii_case("auto") {
+        ModelLanguage::Auto
+    } else if language.eq_ignore_ascii_case("en") {
+        ModelLanguage::En
+    } else {
+        ModelLanguage::Auto
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -102,6 +102,24 @@ fn at01a_missing_model_is_auto_downloaded() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn at01b_language_selects_model_variant() -> Result<(), Box<dyn Error>> {
+    let english = sv::model::model_language_for_transcription("en");
+    let auto = sv::model::model_language_for_transcription("auto");
+    let other = sv::model::model_language_for_transcription("es");
+
+    assert_eq!(english, sv::model::ModelLanguage::En);
+    assert_eq!(auto, sv::model::ModelLanguage::Auto);
+    assert_eq!(other, sv::model::ModelLanguage::Auto);
+
+    let english_spec = sv::model::ModelSpec::new(sv::model::ModelSize::Small, english);
+    let auto_spec = sv::model::ModelSpec::new(sv::model::ModelSize::Small, auto);
+
+    assert!(english_spec.filename().contains(".en."));
+    assert!(!auto_spec.filename().contains(".en."));
+    Ok(())
+}
+
+#[test]
 fn at02_missing_model_returns_exit_code_2() -> Result<(), Box<dyn Error>> {
     let config_home = temp_dir("soundvibes-acceptance-config");
     let runtime_dir = temp_dir("soundvibes-acceptance-runtime");


### PR DESCRIPTION
## Summary
- derive model language from transcription language when not explicitly set
- cover language-driven model selection in acceptance tests and docs

## Testing
- cargo test --test acceptance