### PR TITLE
chore: enable manual release workflow runs

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,6 +3,12 @@ name: release-binaries
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or SHA) to build"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -13,12 +19,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install mise
+        uses: jdx/mise-action@v2
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Prepare build dependencies
+        run: mise run prepare-dev
       - name: Build release binary
         run: cargo build --release
       - name: Package artifacts


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger to run release builds from any ref
- align release workflow prerequisites with CI (mise + prepare-dev + submodules)