### PR TITLE
chore: update docs and mise tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,24 +29,14 @@ Quick reference:
 
 ## Build / Run / Lint / Test
 
-These commands are inferred from repo files and standard Rust conventions. Prefer these unless the user requests otherwise.
-
-Build:
-- `cargo build`
-- `cargo build --release`
-
-Run:
-- `cargo run --` (basic CLI)
-- `sv` (after install/build)
-- `sv --daemon` (daemon mode)
+Prefer mise tasks for build/run/test workflows unless the user requests otherwise.
 
 Mise tasks:
-- `mise run download-model` (downloads ggml model)
-- `SIZE=small mise run download-model` (pick model size)
-- `mise run run-local` (alias for `cargo run --`)
-- `mise run debug-local` (runs with local model + VAD debug)
+- `mise run prepare-dev` (install build prerequisites for your distro)
+- `mise run run-local` (run `sv` locally)
+- `mise run ci` (format, lint, tests, release build)
 
-Tests:
+Tests (specific variants):
 - `cargo test` (all tests)
 - `cargo test transcribes_sample_audio` (single test by name)
 - `cargo test --test whisper_integration` (single integration test file)
@@ -54,10 +44,6 @@ Tests:
 - `cargo test --test acceptance` (automated acceptance tests)
 - `cargo test --test acceptance --features test-support` (acceptance tests using test support mocks)
 - `SV_HARDWARE_TESTS=1 cargo test --test acceptance` (hardware acceptance tests)
-
-Formatting / linting:
-- `cargo fmt`
-- `cargo clippy --all-targets --all-features` (use when linting is requested)
 
 Validation plan requirement:
 - Always note which checks you ran or plan to run (tests, manual acceptance checks, etc.).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve SoundVibes. This document is for humans.
+
+Note: This repository is developed by agents using beads for issue tracking. Humans do not need to configure beads to contribute.
+
+## Development Setup
+### Requirements
+- Linux x86_64
+- Rust toolchain (stable)
+- Microphone input device (for runtime tests)
+
+Vulkan GPU acceleration is enabled by default. Install the Vulkan loader + headers for your distro,
+or build CPU-only with `cargo build --no-default-features`.
+
+- Arch Linux:
+  - `sudo pacman -Syu vulkan-headers vulkan-icd-loader vulkan-validation-layers`
+  - GPU ICD: `sudo pacman -S vulkan-radeon` (AMD) or `sudo pacman -S nvidia-utils` (NVIDIA)
+- Ubuntu / Debian:
+  - `sudo apt-get update && sudo apt-get install -y libvulkan-dev vulkan-validationlayers`
+  - GPU ICD: `sudo apt-get install -y mesa-vulkan-drivers` (AMD/Intel) or `sudo apt-get install -y nvidia-driver-<version>`
+- Fedora:
+  - `sudo dnf install -y vulkan-headers vulkan-loader vulkan-validation-layers`
+  - GPU ICD: `sudo dnf install -y mesa-vulkan-drivers` (AMD/Intel) or `sudo dnf install -y akmod-nvidia`
+
+### Clone and Build
+```bash
+git clone https://github.com/kejne/soundvibes.git
+cd soundvibes
+cargo build
+```
+
+### Model Setup
+`sv` downloads the configured whisper.cpp ggml model automatically on first run if it is missing.
+
+## Testing
+- Run all tests: `cargo test`
+- Acceptance tests: `cargo test --test acceptance`
+- Acceptance tests with mocks: `cargo test --test acceptance --features test-support`
+- Hardware acceptance tests: `SV_HARDWARE_TESTS=1 cargo test --test acceptance`
+- Single test: `cargo test transcribes_sample_audio`
+- Integration test: `cargo test --test whisper_integration`
+
+Acceptance criteria live in `docs/acceptance-tests.md` and must map to tests in `tests/acceptance.rs`.
+
+## Linting and Formatting
+- Format: `cargo fmt`
+- Lint: `cargo clippy --all-targets --all-features`
+
+## Mise Tasks
+Common dev tasks are available via mise:
+
+- `mise run prepare-dev` - install build prerequisites for your distro
+- `mise run run-local` - run `sv` with a local model
+- `mise run ci` - run format, lint, tests, and release build
+
+## Pull Requests
+- Prefer small, focused changes.
+- Add or update tests for new behavior.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Offline voice-to-text CLI for Linux.
 ## Overview
 `sv` captures audio from your microphone using start/stop toggles and runs offline speech-to-text with a small whisper.cpp model. It aims for minimal runtime dependencies and ships as a single binary plus a local model file.
 
-## Requirements
+## Quick Start
+### 1) Requirements
 - Linux x86_64
 - Microphone input device
 
@@ -22,32 +23,23 @@ or build CPU-only with `cargo build --no-default-features`.
   - `sudo dnf install -y vulkan-headers vulkan-loader vulkan-validation-layers`
   - GPU ICD: `sudo dnf install -y mesa-vulkan-drivers` (AMD/Intel) or `sudo dnf install -y akmod-nvidia`
 
-## Model Setup
-`sv` will download the configured whisper.cpp ggml model automatically if it is missing.
+### 2) Install from GitHub Releases
+Download the latest Linux release from:
 
-Example (base English model):
+https://github.com/kejne/soundvibes/releases
 
-```bash
-data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/soundvibes/models"
-mkdir -p "$data_dir"
-curl -L -o "$data_dir/ggml-base.en.bin" https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
-```
-
-Or use the mise task:
+Example (replace the version with the latest):
 
 ```bash
-mise run download-model
+curl -L -o soundvibes.tar.gz https://github.com/kejne/soundvibes/releases/download/v0.1.0/soundvibes-linux-x86_64.tar.gz
+tar -xzf soundvibes.tar.gz
+mkdir -p "$HOME/.local/bin"
+mv sv "$HOME/.local/bin/sv"
 ```
 
-Pick a size via `SIZE` (English models only):
+Make sure `~/.local/bin` is on your `PATH`.
 
-```bash
-SIZE=small mise run download-model
-```
-
-Available sizes: `tiny`, `base`, `small`, `medium`, `large`.
-
-## Configuration
+### 3) Configure
 Create a config file at `${XDG_CONFIG_HOME:-~/.config}/soundvibes/config.toml`.
 
 ```toml
@@ -67,16 +59,25 @@ If `model` is omitted, `sv` builds a default model path under
 `${XDG_DATA_HOME:-~/.local/share}/soundvibes/models/` based on `model_size` and
 `model_language` (defaults to the small general model).
 
-## Usage
+`sv` downloads the model automatically on first run if it is missing.
+
+### 4) Run
+Start the daemon:
+
 ```bash
 sv --daemon
 ```
 
-In another terminal:
+In another terminal, trigger a capture:
 
 ```bash
 sv
 ```
+
+## Environment Setup Tips
+- i3: add a keybinding to run `sv`, and let a user systemd service or `exec --no-startup-id sv --daemon` keep the daemon alive.
+- Hyprland: use `exec-once = sv --daemon` in `hyprland.conf`, plus `bind = SUPER, V, exec, sv` for capture.
+- GNOME: add a custom keyboard shortcut (Settings -> Keyboard -> View and Customize Shortcuts) with command `sv`, and use Startup Applications or a user systemd service for the daemon.
 
 ## Daemon Lifecycle
 Run `sv --daemon` in the foreground for quick tests, or use a user systemd service
@@ -89,7 +90,7 @@ Example user unit (`~/.config/systemd/user/sv.service`):
 Description=SoundVibes daemon
 
 [Service]
-ExecStart=%h/.cargo/bin/sv --daemon
+ExecStart=%h/.local/bin/sv --daemon
 Restart=on-failure
 
 [Install]
@@ -126,19 +127,5 @@ Set `mode = "inject"` in the config to inject text at the focused cursor.
 - Technical design: `docs/technical-design.md`
 - Acceptance tests: `docs/acceptance-tests.md`
 
-## Validation
-These steps align with `docs/acceptance-tests.md`.
-
-1. Ensure the model is downloaded (see Model Setup).
-2. Create a valid config file (see Configuration).
-3. Start the CLI:
-   ```bash
-   sv
-   ```
-4. Verify the missing-model behavior:
-   ```bash
-   sv
-   ```
-   Update `model` in the config to the missing path first.
-5. Run the remaining acceptance checks (device errors, JSONL output, offline mode)
-   as listed in `docs/acceptance-tests.md`.
+## Contributing
+See `CONTRIBUTING.md` for development setup, tests, and workflow.

--- a/mise.toml
+++ b/mise.toml
@@ -5,17 +5,9 @@ PATH = "{{ env.HOME }}/.local/share/vulkan-sdk/current/x86_64/bin:{{ env.PATH | 
 LD_LIBRARY_PATH = "{{ env.HOME }}/.local/share/vulkan-sdk/current/x86_64/lib:{{ env.LD_LIBRARY_PATH | default(value=\"\") }}"
 VK_LAYER_PATH = "{{ env.HOME }}/.local/share/vulkan-sdk/current/x86_64/etc/vulkan/explicit_layer.d:{{ env.VK_LAYER_PATH | default(value=\"\") }}"
 
-[tasks.download-model]
-description = "Download a whisper.cpp English model by size"
-run = "data_dir=${XDG_DATA_HOME:-$HOME/.local/share}/soundvibes/models && mkdir -p \"$data_dir\" && size=${SIZE:-base} && model=ggml-${size}.en.bin && curl -L -o \"$data_dir/${model}\" \"https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${model}\""
-
 [tasks.run-local]
 description = "Run sv with local model"
 run = "cargo run --"
-
-[tasks.debug-local]
-description = "Run sv with local model"
-run = "cargo run -- --model ./models/ggml-tiny.en.bin --debug-vad"
 
 [tasks.ci]
 description = "Run full CI quality gates"


### PR DESCRIPTION
## Summary
- refresh README quick start for release installs and auto model downloads
- add human-focused CONTRIBUTING guide and lighten agent instructions
- remove deprecated mise tasks

## Testing
- not run (docs and config-only changes)