### PR TITLE
chore: build releases on ubuntu-20.04

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- build release binaries on ubuntu-20.04 to lower glibc requirements
- keep packaging and release assets unchanged