### PR TITLE
feat: split release build from CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,28 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          shared-key: "rust-cache"
       - name: Prepare build dependencies
         run: mise run prepare-dev
       - name: Run quality gates
         run: mise run ci
+
+  build-release:
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install mise
+        uses: jdx/mise-action@v2
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "rust-cache"
+      - name: Prepare build dependencies
+        run: mise run prepare-dev
+      - name: Build release binary
+        run: mise run build-release

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,11 @@ run = "cargo run --"
 
 [tasks.ci]
 description = "Run full CI quality gates"
-run = "cargo fmt --check && cargo clippy --all-targets --all-features && cargo test && cargo build --release"
+run = "cargo fmt --check && cargo clippy --all-targets --all-features && cargo test"
+
+[tasks.build-release]
+description = "Build release binary"
+run = "cargo build --release"
 
 [tasks.prepare-dev]
 description = "Install build prerequisites based on OS"


### PR DESCRIPTION
## Summary
- Splits the release build from the CI quality gates task to improve CI performance
- Release build now runs in parallel but is not a required status check
- Quality gates remain required and run faster without the release build

## Changes
- Modified  to separate  task (fmt, clippy, tests) from new  task
- Updated GitHub Actions workflow to run both jobs in parallel
- Added shared cache key to improve cache utilization between jobs