### PR TITLE
chore: update release runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,8 +14,8 @@ permissions:
   contents: write
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-20.04
+   build-linux:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Update the release pipeline to use Ubuntu 22.04 instead of the unsupported Ubuntu 20.04.