### PR TITLE
ci: Add path-filtered CI checks with gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,29 @@ permissions:
   contents: read
 
 jobs:
-  quality-gates:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'build.rs'
+            web:
+              - 'web/**'
+
+  rust-checks:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,22 +49,65 @@ jobs:
       - name: Run quality gates
         run: mise run ci
 
-  build-release:
+  web-checks:
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ubuntu-latest
-    needs: []
+    defaults:
+      run:
+        working-directory: web
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          submodules: recursive
-      - name: Install mise
-        uses: jdx/mise-action@v2
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "rust-cache"
-      - name: Prepare build dependencies
-        run: mise run prepare-dev
-      - name: Build release binary
-        run: mise run build-release
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Test UI
+        run: npm run test:ui
+
+  ci-gate:
+    needs: [changes, rust-checks, web-checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CI gate
+        run: |
+          RUST_NEEDED="${{ needs.changes.outputs.rust }}"
+          WEB_NEEDED="${{ needs.changes.outputs.web }}"
+          RUST_RESULT="${{ needs.rust-checks.result }}"
+          WEB_RESULT="${{ needs.web-checks.result }}"
+
+          EXIT_CODE=0
+
+          if [ "$RUST_NEEDED" == "true" ]; then
+            if [ "$RUST_RESULT" != "success" ]; then
+              echo "❌ Rust checks failed or were cancelled"
+              EXIT_CODE=1
+            else
+              echo "✓ Rust checks passed"
+            fi
+          else
+            echo "⊘ Rust checks skipped (no Rust files changed)"
+          fi
+
+          if [ "$WEB_NEEDED" == "true" ]; then
+            if [ "$WEB_RESULT" != "success" ]; then
+              echo "❌ Web checks failed or were cancelled"
+              EXIT_CODE=1
+            else
+              echo "✓ Web checks passed"
+            fi
+          else
+            echo "⊘ Web checks skipped (no web files changed)"
+          fi
+
+          exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds path-filtered CI jobs to reduce redundant checks and speed up PRs.

### Changes

- **Path filtering**: Uses `dorny/paths-filter` to detect Rust vs Web changes
  - Rust: `**/*.rs`, `Cargo.toml`, `Cargo.lock`, `build.rs`
  - Web: `web/**`
  
- **Separate jobs**:
  - `rust-checks`: Runs `mise run ci` (format, clippy, tests) only when Rust files change
  - `web-checks`: Runs lint, build, and UI tests only when web files change

- **CI gate job**: `ci-gate` always runs and validates that required jobs passed
  - This is the job to set as required in branch protection
  - Handles skipped jobs correctly (they don't fail the gate)

- **Removed**: `build-release` job (no longer needed in PR CI)

### Benefits

- Web-only changes no longer trigger slow Rust tests
- Rust-only changes no longer trigger web build/tests
- Branch protection can require `ci-gate` which always passes appropriately

### Validation

- [ ] CI passes on this PR
- [ ] After merge: Update branch protection to require `ci-gate`