### PR TITLE
fix(web): correct product messaging and add X11/Wayland selling point

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -79,6 +79,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <p class="font-semibold text-ink">Fast toggling</p>
           <p>Toggle capture while you talk, transcripts land when you stop.</p>
         </div>
+        <div class="rounded-2xl border border-ink/10 bg-white px-4 py-4">
+          <p class="font-semibold text-ink">X11 & Wayland</p>
+          <p>Works seamlessly on both, text appears right where your cursor is.</p>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Clarify that transcript appears at cursor after toggle off (not auto-detected)
- Rephrase use cases to emphasize using sv FOR vibe coding
- Add X11 & Wayland seamless support as a key selling point