### PR TITLE
feat: update homepage selling points to emphasize open source

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -6,10 +6,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <section class="mx-auto grid w-full max-w-6xl gap-12 px-6 pb-16 pt-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
     <div class="space-y-8" data-smoke="hero">
       <div class="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-ink/70">
-        Offline Speech-to-Text for Linux
+        Open Source Speech-to-Text for Linux
       </div>
       <h1 class="font-display text-4xl font-semibold leading-tight text-ink sm:text-5xl">
-        Capture voice notes without cloud latency, scripts, or surprises.
+        An open source tool to capture voice notes without cloud latency, scripts, or surprises.
       </h1>
       <p class="max-w-xl text-lg text-ink/70">
         Soundvibes keeps your workflow local. Vulkan-only system dependencies, automatic model downloads,
@@ -29,14 +29,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           Documentation
         </a>
       </div>
-      <div class="flex items-center gap-2 text-sm text-ink/60">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="text-citrus">
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-        </svg>
-        <a href="https://github.com/kejne/soundvibes" target="_blank" rel="noopener noreferrer" class="underline transition hover:text-ink">
-          Star us on GitHub
-        </a>
-      </div>
+
       <div class="grid gap-3 text-sm text-ink/70 sm:grid-cols-2">
         <div class="flex items-center gap-2">
           <span class="h-2 w-2 rounded-full bg-mint"></span>


### PR DESCRIPTION
## Summary

Replaced weak selling points on the homepage with stronger ones:

- 'No daemon babysitting' → 'Open source'
- 'GitHub Releases only' → 'Easy to get started'

These changes better communicate the value proposition to users by highlighting that Soundvibes is open source and simple to set up.